### PR TITLE
Fixed entryPoint.sh commands

### DIFF
--- a/entryPoint.sh
+++ b/entryPoint.sh
@@ -1,4 +1,2 @@
-#!/bin/bash
-envsubst < /usr/share/nginx/html/assets/config/config.template.json > /usr/share/nginx/html/assets/config/config.json
-nginx -g 'daemon off;' &
-java -jar /app/mockpit-server.jar
+#!/bin/sh
+envsubst < /usr/share/nginx/html/assets/config/config.template.json > /usr/share/nginx/html/assets/config/config.json && exec nginx -g 'daemon off;' & java -jar /app/mockpit-server.jar


### PR DESCRIPTION
Next line characters in entryPoint.sh script was causing following error while running Docker container:
`: not found.sh: line 3: `

Removed next line characters, used `&& exec` to concat `envsubst` and `nginx & java` commands.